### PR TITLE
click~=7.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setuptools.setup(
     },
     install_requires=[
         # 'attrs',
-        'click',
+        'click~=7.1',
         'requests',
     ],
     extras_require={


### PR DESCRIPTION
Some weird stuff with click 8 on windows and expanding wildcards and...

https://github.com/altendky/boots/blob/9d399eed1fb7448dd3be7e707a787202f1755918/boots.py#L674-L689
```python
        check_call(
            [
                os.path.join(configuration.resolved_venv_common_bin(), 'romp'),
                '--command', 'python {} lock --use-default-python'.format(os.path.basename(__file__)),
                '--platform', 'Windows',
                '--interpreter', 'CPython',
                '--version', version,
                '--architecture', architecture,
                # '--include', 'Windows', 'CPython', version, 'x86',
                '--include', 'Linux', 'CPython', version, 'x86_64',
                '--include', 'macOS', 'CPython', version, 'x86_64',
                '--archive-file', archive_path,
                '--artifact-paths', artifact_paths,
                '--artifact', artifact_path,
            ]
        )
```

https://click.palletsprojects.com/en/8.0.x/changes/#version-8-0-1
> Pass windows_expand_args=False when calling the main command to disable pattern expansion on Windows. There is no way to escape patterns in CMD, so if the program needs to pass them on as-is then expansion must be disabled. https://github.com/pallets/click/issues/1901

https://click.palletsprojects.com/en/8.0.x/changes/#version-8-0-0
> When taking arguments from sys.argv on Windows, glob patterns, user dir, and env vars are expanded. https://github.com/pallets/click/issues/1096